### PR TITLE
Removed ann_list from project, added file read from ann_models dir by…

### DIFF
--- a/inversion/WiFiRSSIPropagation.py
+++ b/inversion/WiFiRSSIPropagation.py
@@ -11,18 +11,21 @@ ann_logger = setup_logger('ga_invert',
 
 
 class WifiRSSIPropagation():
-    def __init__(self, name, model, scaler):
+    def __init__(self, scaler, name):
         ann_logger.info("Instantiated GA_Inverter method")
-        self.model = model
         self.scaler = scaler
         self.name = name
+        self.model = WifiRSSIPropagation.load_model("model/ann_models/{}".format(name))
 
     @staticmethod
     def load_model(filepath):
         with open(filepath, "rb") as fp:
             return pickle.load(fp)
 
+
+
     @staticmethod
-    def save_model(filepath,wifirssiprop):
+    def save_model(filepath, wifirssiprop):
         with open(filepath, "wb") as fp:
             pickle.dump(wifirssiprop, fp)
+

--- a/inversion/ann_training.py
+++ b/inversion/ann_training.py
@@ -1,10 +1,10 @@
 import os
 import pickle
 from datetime import datetime
-import sklearn_export
-from sklearn_export import Export
+
 from sklearn.model_selection import train_test_split, GridSearchCV
 from sklearn.neural_network import MLPRegressor
+from sklearn_export import Export
 
 from util.util import setup_logger
 
@@ -25,15 +25,14 @@ ann_logger = setup_logger('ann_training',
 
 def create_ANN_list(df_list, target_list, model=__defaultmodel, grid_search=False):
     ann_logger.info("Started create_ANN_list method")
-    ann_list = []
     if grid_search:
         for (testDataFrame, target) in zip(df_list, target_list):
-            ann_list.append(__grid_search_ANN(testDataFrame, target))
+            __grid_search_ANN(testDataFrame, target)
     else:
         for (testDataFrame, target) in zip(df_list, target_list):
-            ann_list.append(__train_ANN(testDataFrame, target, model))
+            __train_ANN(testDataFrame, target, model)
     ann_logger.info("Done create_ANN_list method")
-    return ann_list
+    return
 
 
 def __train_ANN(features, target, model):
@@ -42,23 +41,23 @@ def __train_ANN(features, target, model):
     model.fit(x_train, y_train)
     ann_logger.info("Finished  training for {}".format(target.name))
     ann_logger.info("Saving model for  {}".format(target.name))
-    __save_model(model, "{}_{}_{}_{}_{}".format(target.name, current_datetime.year, current_datetime.month,
-                                                current_datetime.day,
-                                                current_datetime.hour))
+    __save_model(model, "{}".format(target.name))
     ann_logger.debug("Model score of {} : {}".format(target.name, model.score(x_test, y_test)))
-    return model
+    return
 
 
 def __grid_search_ANN(features, target):
     x_train, x_test, y_train, y_test = train_test_split(features, target)
     ann_logger.info("Starting training for the {}".format(target.name))
+
     parameter_space = {
         'hidden_layer_sizes': [(8, 16, 32, 64)],
-        'activation': ['tanh', 'relu', 'linear'],
+        'activation': ['tanh', 'relu', 'identity'],
         'solver': ['lbfgs', 'sgd', 'adam'],
         'alpha': [0.003, 0.001, 0.0003, 0.0001],
         'learning_rate_init': [0.03, 0.01, 0.003, 0.001, 0.0001],
     }
+
     clf = GridSearchCV(MLPRegressor(max_iter=2000, learning_rate="adaptive"), parameter_space, n_jobs=-1, verbose=2)
     clf.fit(x_train, y_train)
     ann_logger.debug(clf.best_estimator_)
@@ -67,21 +66,19 @@ def __grid_search_ANN(features, target):
     ann_logger.info("Finished  training for {}".format(target.name))
     ann_logger.info("Saving model for  {}".format(target.name))
     model = clf.best_estimator_
-    __save_model(model, "{}_{}_{}_{}_{}".format(target.name, current_datetime.year, current_datetime.month,
-                                                current_datetime.day,
-                                                current_datetime.hour))
+    __save_model(model, "{}".format(target.name))
     ann_logger.debug("Model score of {} : {}".format(target.name, model.score(x_test, y_test)))
-    return model
+    return
 
 
 def __save_model(model, name):
-    if not os.path.exists('models/ann_models'):
-        os.makedirs('models/ann_models')
-    loc = "models/ann_models/{}".format(name)
+    if not os.path.exists('model/ann_models'):
+        os.makedirs('model/ann_models')
+    loc = "model/ann_models/{}".format(name)
     with open(loc, "wb") as fp:
         pickle.dump(model, fp)
-    if not os.path.exists('models/ann_models/json'):
-        os.makedirs('models/ann_models/json')
-    export=Export(model)
-    export.to_json(directory="models/ann_models/json", filename="{}.json".format(name))
+    if not os.path.exists('model/ann_models/json'):
+        os.makedirs('model/ann_models/json')
+    export = Export(model)
+    export.to_json(directory="model/ann_models/json", filename="{}.json".format(name))
     ann_logger.info("Model pickling for  {} complete!".format(name))

--- a/main.py
+++ b/main.py
@@ -5,9 +5,9 @@ import numpy as np
 import pandas as pd
 from sklearn.metrics import mean_squared_error, r2_score
 
+from inversion.WiFiRSSIPropagation import WifiRSSIPropagation
 from inversion.ann_training import create_ANN_list
 from inversion.util.inversion_util import get_possible_inputs, average_xy_positions
-from inversion.WiFiRSSIPropagation import WifiRSSIPropagation
 from util import util
 
 pd.set_option('display.max_rows', 500)
@@ -56,17 +56,13 @@ def main():
         logger.debug("{}".format(dataframe.describe()))
 
     if clean_run:
-        model_list = create_ANN_list(df_list, target_list, grid_search=True)
-        with open("model/model_list", "wb") as fp:
-            pickle.dump(model_list, fp)
+        create_ANN_list(df_list, target_list, grid_search=True)
 
-    with open("model/model_list", "rb") as fp:
-        model_list = pickle.load(fp)
 
     # MODEL LIST + SCALER LIST + Target names->wifi_rssi_propagation_model list
     ann_comp_list = []
-    for model, scaler, target in zip(model_list, scaler_list, target_list):
-        ann_comp_list.append(WifiRSSIPropagation(model, scaler, target.name))
+    for scaler, target in zip(scaler_list, target_list):
+        ann_comp_list.append(WifiRSSIPropagation(scaler, target.name))
 
     if clean_run:
         list_of_inputs = util.create_inputs_by_index(selected_features, df_list_unscaled)


### PR DESCRIPTION
… name

-Refactored WiFiRSSIPropagation.py to not require model parameter in constructor.
- WiFiRSSIPropagation.py now unpacks the models from ann_models directory by name instead
- Removed any usage of ann_list from project
- Timestamp part of the model names have been removed in order to be consistently read in the creation of WiFiRSSIPropagation list
Bug fixes:
- ann_training.py __save_model method used the directory "models" instead of model


closes #24 #23 