### PR TITLE
Separated main into two utility methods for easy testing:

### DIFF
--- a/inversion/WiFiRSSIPropagation.py
+++ b/inversion/WiFiRSSIPropagation.py
@@ -22,10 +22,7 @@ class WifiRSSIPropagation():
         with open(filepath, "rb") as fp:
             return pickle.load(fp)
 
-
-
     @staticmethod
     def save_model(filepath, wifirssiprop):
         with open(filepath, "wb") as fp:
             pickle.dump(wifirssiprop, fp)
-


### PR DESCRIPTION
- ann_generation generates the ANN_models.
 - grid_search is now a parameter of the ann_generation method
- inversion inverts the generated models.
- changed clean_run global variable to be a parameter to the two methods. clean_run can be set to false to skip the computationally expensive steps of the ann generation and inversion and load them from pickled files.